### PR TITLE
Bigger hit area for less annoyance

### DIFF
--- a/gtk-2.0/gtkrc
+++ b/gtk-2.0/gtkrc
@@ -19,7 +19,7 @@ style "default" {
 	GtkRadioButton::indicator-size = 14
 	GtkPaned::handle-size = 6
 
-	GtkRange::trough-border = 1
+	GtkRange::trough-border = 0
 	GtkRange::slider-width = 13
 	GtkRange::stepper-size = 12
 

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -1066,7 +1066,7 @@ GtkProgressBar {
     background-image: none;
     background-color: shade(@theme_bg_color, 0.85);
     border-style: solid;
-    border-width: 1px;
+    border-width: 0px;
 
     color: @theme_text_color;
     border-color: shade(@theme_bg_color, 0.7);


### PR DESCRIPTION
There was a little 1px border on the right where I could click on but nothing happened. I think this is wasted space without any use and is very annoying!

I also think, you cannot imagine any argument to keep that in your style since 1px actually is really small.
